### PR TITLE
campaign order admin edit  fix

### DIFF
--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -1,4 +1,4 @@
-import { MockApi } from "./mock_api";
+// import { MockApi } from "./mock_api";
 import { RestApi } from "./rest_api";
 
 export interface CampaignItem {

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -36,6 +36,7 @@ export interface OrderedItem {
 
 export interface Order {
   campaign_uuid: string;
+  order_uuid: string;
   items: OrderedItem[];
   paid_amount: number;
 }

--- a/src/api/mock_data/orders.ts
+++ b/src/api/mock_data/orders.ts
@@ -25,7 +25,7 @@ export const orders: { [key: string]: Order[] } = {
     },
     {
       campaign_uuid: "a170039a-9917-4168-aee1-aedb77afe34e",
-      order_uuid: "9vn20986h764v"
+      order_uuid: "9vn20986h764v",
       paid_amount: 221,
       items: [{ amount: 1, item_uuid: "9ed31265-54cb-4e6d-af3d-ca8ba8942b37" }],
     },

--- a/src/api/mock_data/orders.ts
+++ b/src/api/mock_data/orders.ts
@@ -4,6 +4,7 @@ export const orders: { [key: string]: Order[] } = {
   userX: [
     {
       campaign_uuid: "97c921aa-d1c3-4e34-8c72-bc620f566970",
+      order_uuid: "90354820v905v3-c89275489vb-8v67",
       paid_amount: 100,
       items: [
         { amount: 1, item_uuid: "1dfb1dae-7b1f-475f-84a9-a562d68d1c22" },
@@ -15,6 +16,7 @@ export const orders: { [key: string]: Order[] } = {
   "test-user": [
     {
       campaign_uuid: "97c921aa-d1c3-4e34-8c72-bc620f566970",
+      order_uuid: "90354820v905v3-c89275489v-453276g",
       paid_amount: 200,
       items: [
         { amount: 1, item_uuid: "1dfb1dae-7b1f-475f-84a9-a562d68d1c22" },
@@ -23,6 +25,7 @@ export const orders: { [key: string]: Order[] } = {
     },
     {
       campaign_uuid: "a170039a-9917-4168-aee1-aedb77afe34e",
+      order_uuid: "9vn20986h764v"
       paid_amount: 221,
       items: [{ amount: 1, item_uuid: "9ed31265-54cb-4e6d-af3d-ca8ba8942b37" }],
     },

--- a/src/api/rest_api.ts
+++ b/src/api/rest_api.ts
@@ -53,6 +53,7 @@ function backend_user_to_frontend_user(user: any): User {
 function backend_order_to_frontend_order(order: any): Order {
   return {
     campaign_uuid: order.uuid,
+    order_uuid: order.order_uuid,
     paid_amount: Number.parseInt(order.paid_amount),
     items: order.items?.map((i) => ({
       item_uuid: i.uuid,
@@ -130,6 +131,7 @@ export class RestApi implements Api {
       const payload = {
         paid_amount: order.paid_amount,
         campaign_uuid: order.campaign_uuid,
+        order_uuid: order.order_uuid,
       };
       const response = await fetch(
         api_url + "campaigns/" + order.campaign_uuid + "/order",
@@ -167,13 +169,13 @@ export class RestApi implements Api {
       };
       const response = update.is_new
         ? await fetch(
-            api_url + "campaigns/" + campaign_uuid + "/order",
-            options("POST", payload)
-          )
+          api_url + "campaigns/" + campaign_uuid + "/order",
+          options("POST", payload)
+        )
         : await fetch(
-            api_url + "campaigns/" + campaign_uuid + "/order",
-            options("PATCH", payload)
-          );
+          api_url + "campaigns/" + campaign_uuid + "/order",
+          options("PATCH", payload)
+        );
       if (response.ok) {
         const response_json = await response.json();
         return backend_order_to_frontend_order(response_json.result[0]);

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -8,7 +8,7 @@ export const user_uuid: Writable<string> = writable(null);
 export const access_token: Writable<string> = writable(null);
 
 export const api_url: Readable<string> = readable(
-  "https://bones.usermd.net/api/"
+  "http://localhost:3000/api/"
 );
 
 export function switchToLoggedUser() {


### PR DESCRIPTION
zamowienia rozpoznawane po order uuid (wcześniej campaign_uuid + user_id - brany z tokena powodował błąd w zapisie kwoty zapłaconej)